### PR TITLE
Take into account the breadcrumb config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/config/breadcrumb.php
+++ b/config/breadcrumb.php
@@ -14,7 +14,9 @@
 |   ['tag_close'] 	The closing tag placed on the right side of the breadcrumb.
 |
 */
-
+$config['divider'] = '';
+$config['tag_open'] = '';
+$config['tag_close'] = '';
 
 /* End of file breadcrumb.php */
 /* Location: ./application/config/breadcrumb.php */

--- a/config/breadcrumb.php
+++ b/config/breadcrumb.php
@@ -14,9 +14,9 @@
 |   ['tag_close'] 	The closing tag placed on the right side of the breadcrumb.
 |
 */
-$config['divider'] = '';
-$config['tag_open'] = '';
-$config['tag_close'] = '';
+$config['divider']   = ' &nbsp;&#8250;&nbsp; ';
+$config['tag_open']  = '<div id="breadcrumb">';
+$config['tag_close'] = '</div>';
 
 /* End of file breadcrumb.php */
 /* Location: ./application/config/breadcrumb.php */

--- a/libraries/Breadcrumb.php
+++ b/libraries/Breadcrumb.php
@@ -26,6 +26,12 @@ class Breadcrumb {
 	private $_tag_open 		= '<div id="breadcrumb">';
 	private $_tag_close 	= '</div>';
 	
+    /**
+     * CodeIgniter Instance
+     *
+     */
+    private $_ci;
+    
 	/**
 	 * Constructor
 	 *
@@ -34,10 +40,18 @@ class Breadcrumb {
 	 */
 	public function __construct($params = array())
 	{
+        $this->_ci = get_instance();
+        $this->_ci->config->load('breadcrumb', TRUE);
+        $config = $this->_ci->config->item('breadcrumb');
+                
 		if (count($params) > 0)
 		{
 			$this->initialize($params);
 		}
+        else
+        {
+            $this->initialize($config);
+        }
 		
 		log_message('debug', "Breadcrumb Class Initialized");
 	}
@@ -63,6 +77,8 @@ class Breadcrumb {
 				}
 			}
 		}
+        
+        var_dump($this->_divider, $this->_tag_open, $this->_tag_close);
 	}
 	
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Right now there is not way of setting a custom divider, open tag or closing tag for breadcrumbs. This pull request changes that.
